### PR TITLE
Check priority

### DIFF
--- a/classes/TemplateFunctions.class.php
+++ b/classes/TemplateFunctions.class.php
@@ -179,10 +179,14 @@ class TemplateFunctions {
 			} else {
 				$r_ttl = $entry->ttl;
 			}
-			if (!isset($entry->priority)) {
-				$r_prio = PowerDNSConfig::DNS_DEFAULT_RECORD_PRIORITY;
+			if (($entry->type == "MX") || ($entry->type == "SRV")) {
+				if (!isset($entry->priority)) {
+					$r_prio = PowerDNSConfig::DNS_DEFAULT_RECORD_PRIORITY;
+				} else {
+					$r_prio = $entry->priority;
+				}
 			} else {
-				$r_prio = $entry->priority;
+				$r_prio = null;
 			}
 
 			if ($record->execute() === false) {

--- a/classes/Validators.class.php
+++ b/classes/Validators.class.php
@@ -322,7 +322,7 @@ class RecordValidator extends Validator {
 		),
 		"priority" => array(
 			"valid_priority" => array(
-				"rule" => VALID_INT,
+				"rule" => array("check_record_priority"),
 				"code" => "RECORD_INVALID_PRIORITY",
 				"message" => "Record priority is not valid. Must be an integer."
 			)
@@ -645,6 +645,20 @@ class RecordValidator extends Validator {
 
 		return true;
 	}
+
+	public function check_record_priority($content) {
+	  if (($this->type == "MX") || ($this->type == "SRV")) {
+			if (preg_match(VALID_INT, $content)) {
+				return true;
+			}
+		} else {
+			if (preg_match(VALID_INT, $content) || !isset($content)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
 }
 
 class ArpaValidator extends Validator {

--- a/db/tables.sql
+++ b/db/tables.sql
@@ -53,7 +53,7 @@ CREATE TABLE IF NOT EXISTS `zone_templ_records` (
   `type` varchar(6) NOT NULL,
   `content` varchar(255) NOT NULL,
   `ttl` bigint(20) NOT NULL,
-  `prio` bigint(20) NOT NULL,
+  `prio` bigint(20) DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `zone_templ_id` (`zone_templ_id`)
 ) ENGINE=InnoDB  DEFAULT CHARSET=latin1 ;


### PR DESCRIPTION
Hi, 

priortity is only necessary for MX , SRV record.
Now, all records are set to specified value or DNS_DEFAULT_RECORD_PRIORITY.
Therefore,  inconsistencies also occur with using other PowerDNS Admin Tools.

So I changed that other records except MX and SRV are NULL.
I am grateful if you would apply the patch.

regards,

Signed-off-by: Kouhei Maeda mkouhei@palmtb.net
