### PR TITLE
valid quotatation

### DIFF
--- a/classes/Validators.class.php
+++ b/classes/Validators.class.php
@@ -21,7 +21,7 @@ define("VALID_NOTEMPTY", "#^.+$#");
 define("VALID_INT", "#^[0-9]+$#");
 define("VALID_NAME", "#^[\w_-]+$#");
 define("VALID_STRING", "#^[\w -+.]*$#");
-define("VALID_QUOTED", "#^[\"']{1}.*[\"']{1}$#");
+define("VALID_QUOTED", "#^[\"]{1}.*[\"]{1}$#");
 define("VALID_TOKEN", "#^[0-9a-f]{40}$#");
 define("VALID_ZONE_TYPE", "#MASTER|SLAVE|NATIVE#");
 if (ValidatorConfig::BIND_COMPATABILITY === true) {


### PR DESCRIPTION
Hi,

VALID_QUOTED is require singlie quotation now, but TXT record format does not need it in RFC 1464.

cf. http://www.ietf.org/rfc/rfc1464.txt

$ dig @127.0.0.1 test1.example.org  any
(snip)
;; ANSWER SECTION:
test1.example.org.      3600    IN      TXT     "'hogehoge'"  <= current specification (rev 6cace7b)
test1.example.org.      3600    IN      TXT     "hoge" <= applied my patch

regard,
