### PR TITLE
Change validate soa content

### DIFF
--- a/classes/Validators.class.php
+++ b/classes/Validators.class.php
@@ -585,9 +585,11 @@ class RecordValidator extends Validator {
 			break;
 		case "SOA":
 			$parts = explode(" ", $content);
-			if (count($parts) !== 7) {
+			if ((count($parts) !== 7) && (count($parts) !== 3)) {
 				return array(
-					"message" => $prefix . "A SOA record must provide all 7 parts: <primary> <hostmaster> <serial> <refresh> <retry> <expire> <default_ttl>",
+					"message" => $prefix . "A SOA record must provide all 7 parts: <primary> <hostmaster> <serial> <refresh> <retry> <expire> <default_ttl>\n" .
+					"required: <primary> <hostmaster> <serial>\n" .
+					"optional: <refresh> <retry> <expire> <default_ttl>, pdns has default values are 10800 3600 604800 3600",
 					"code" => "RECORD_RHS_SOA_PARTS_MISSING"
 				);
 			}


### PR DESCRIPTION
Hi,

There are other pdn admin tools requiring primary, hostnamster, serial only.
PowerDNS also has default values of SOA fields.

Then, I hope allowing three parameters.
- allow SOA three fields that <primary> <hostmaster> <serial>
  - When not specified other 4 fields, PowerDNS use default vaules
    - Default value <refresh> <retry> <expire> <default_ttl> are 10800 3600 604800 3600
  - see more http://doc.powerdns.com/types.html

regards,
