### PR TITLE
Fix get all zones

### DIFF
--- a/classes/ZoneResource.class.php
+++ b/classes/ZoneResource.class.php
@@ -92,7 +92,7 @@ class ZoneResource extends TokenResource {
 		$data = $request->parseData();
 
 		if (empty($identifier)) {
-			if ($data === null) {
+			if ($data == null) {
 				return ZoneFunctions::get_all_zones($response);
 			} else {
 				$validator = new ZoneValidator($data);


### PR DESCRIPTION
Hi, 

When GET /zone without identifier,  but BODY_MALFORMED Error occurs.

``` bash
$ curl -k -X PUT https://localhost/authenticate -d'{"username":"username","password":"password"}' && \
curl  -k -X GET -H "x-authentication-token:0011917c0d0cf58d23343b406dca6ea03d29601b" https://localhost/zone 
{"username":"username","valid_until":1338849946,"hash":"0011917c0d0cf58d23343b406dca6ea03d29601b","token":"0011917c0d0cf58d23343b406dca6ea03d29601b"}
{"error":"Query was missing. Ensure that the body is in valid format and all required parameters are present.","detail":{"code":"BODY_MALFORMED"}}
```

In php error log, below log records.

``` syslog
Jun  5 07:44:46 hostname TonicDNS[28874]: (127.0.0.1) [username] GET 400 /zone - Query was missing. Ensure that the body is in valid format and 
all required parameters are present.
Jun  5 07:44:46 hostname TonicDNS[28874]: (127.0.0.1) [username] Input: []
```

So I fixed null check in classes/ZoneResource.class.php, this problem was solved.

``` bash
$ curl -k -X PUT https://localhost/authenticate -d'{"username":"username","password":"password"}' &&\
curl  -k -X GET -H "x-authentication-token:0011917c0d0cf58d23343b406dca6ea03d29601b" https://localhost/zone 
{"username":"username","valid_until":1338850392,"hash":"0011917c0d0cf58d23343b406dca6ea03d29601b","token":"0011917c0d0cf58d23343b406dca6ea03d29601b"}[{"name":"example.org","type":"MASTER","notified_serial":"2012052201"},{"name":"example.net","type":"MASTER","notified_serial":"2012053005"}]
```

Please merge this patch. 

regards,

Signed-off-by: Kouhei Maeda mkouhei@palmtb.net
