### PR TITLE
Fix spelling error of 'separate'

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This a RESTful API for PowerDNS licensed under GPL. It uses the MIT licensed Ton
 Features:
 
 * Token based communication.
-* Option to store tokens in the PowerDNS database, or in a seperate SQLite database.
+* Option to store tokens in the PowerDNS database, or in a separate SQLite database.
 * Should work with any PowerDNS backend database, tested with MySQL.
 * Supports adding of zones, records and zone and record templates.
 * Atomic commits, all modifications are validated on input and executed in a single transaction.
@@ -35,7 +35,7 @@ Clone the repo.
 $ git clone git://github.com/Cysource/TonicDNS.git
 ```
 
-Create a new VirtualHost in Apache. I recommend using mod_itk and using a seperate user account for running TonicDNS. I also recommend running the communication over SSL, as TonicDNS doesn't provide any encryption on its own (nor will it ever). The example below assumes you follow these recommendations. 
+Create a new VirtualHost in Apache. I recommend using mod_itk and using a separate user account for running TonicDNS. I also recommend running the communication over SSL, as TonicDNS doesn't provide any encryption on its own (nor will it ever). The example below assumes you follow these recommendations. 
 
 ```
 <VirtualHost *:80>

--- a/classes/ArpaResource.class.php
+++ b/classes/ArpaResource.class.php
@@ -30,7 +30,7 @@ class ArpaResource extends TokenResource {
 	 * Retrieves an existing reverse DNS record.
 	 *
 	 * If a query is specified in the URL, all records matching the IPs or ranges
-	 * are returned. Multiple queries may be specified, and must be comma seperated.
+	 * are returned. Multiple queries may be specified, and must be comma separated.
 	 *
 	 * If an identifier is specified, the reverse DNS record for one IP will be 
 	 * retrieved.

--- a/classes/Validators.class.php
+++ b/classes/Validators.class.php
@@ -759,7 +759,7 @@ class ArpaValidator extends Validator {
 			"valid_query" => array(
 				"rule" => VALID_RANGE_QUERY,
 				"code" => "ARPA_INVALID_QUERY",
-				"message" => "Query is invalid. May only contain alphanumeric characters, dashes (-), dots (.) and wildcards (*). Multiple queries must be seperated by comma's."
+				"message" => "Query is invalid. May only contain alphanumeric characters, dashes (-), dots (.) and wildcards (*). Multiple queries must be separated by comma's."
 			)
 		),
 	);

--- a/docs/ArpaResource.md
+++ b/docs/ArpaResource.md
@@ -8,7 +8,7 @@ GET
 Retrieves an existing reverse DNS record.
 
 If a query is specified in the URL, all records matching the IPs or ranges
-are returned. Multiple queries may be specified, and must be comma seperated.
+are returned. Multiple queries may be specified, and must be comma separated.
 
 If an identifier is specified, the reverse DNS record for one IP will be 
 retrieved.


### PR DESCRIPTION
Hi,

Fix spelling of separate when I found to packaging deb. :)

regards,

Signed-off-by: Kouhei Maeda mkouhei@palmtb.net
