### PR TITLE
Fix API URI for deleting records in Getting Started doc

### DIFF
--- a/GettingStarted.md
+++ b/GettingStarted.md
@@ -443,7 +443,7 @@ Delete records from the zone.
 
 ### API URI ###
 
-* /zone/:identifier
+* /zone
 
 ### Example ###
 


### PR DESCRIPTION
The API URI for deleting records in the Getting Started doc incorrectly included the :identifier. This has the effect of deleting the zone instead of records within the zone.
