### PR TITLE
Support CAA records

### DIFF
--- a/classes/Validators.class.php
+++ b/classes/Validators.class.php
@@ -43,7 +43,7 @@ define("VALID_QUERY", "#^[a-zA-Z0-9\-\.*]+$#");
 define("VALID_RANGE_QUERY", "#^[a-zA-Z0-9\-\.:*,/]+|$#");
 define("VALID_RECORD_NAME", "#^(?:\*\.)?(?:[A-Z0-9_](?:[A-Z0-9\-_]{0,61}[A-Z0-9])?\.)+[A-Z]{2,61}$#i");
 define("VALID_TEMPLATE_NAME", "#^(?:(?:\*\.)?(?:[A-Z0-9_](?:[A-Z0-9\-_]{0,61}[A-Z0-9])?\.)+(?:[A-Z]{2,61}|\[ZONE\])|(?:\[ZONE\])|(?:\*\.\[ZONE\]))$#i");
-define("VALID_RECORD_TYPE", "#^A|AAAA|CNAME|MX|NAPTR|NS|PTR|RP|SOA|SPF|SSHFP|SRV|TXT$#");
+define("VALID_RECORD_TYPE", "#^(?:A|AAAA|CAA|CNAME|MX|NAPTR|NS|PTR|RP|SOA|SPF|SSHFP|SRV|TXT)$#");
 define("VALID_IPV4", "#^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$#");
 define("VALID_IPV6", "#^(?:(?:[A-F0-9]{1,4}:){7}[A-F0-9]{1,4}|(?=(?:[A-F0-9]{0,4}:){0,7}[A-F0-9]{0,4}$)(([0-9A-F]{1,4}:){1,7}|:)((:[0-9A-F]{1,4}){1,7}|:))$#i");
 define("VALID_IPV4_RANGE", "#^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)/[0-9]{1,2}$#");

--- a/tests/tonicdns/ValidatorsTest.php
+++ b/tests/tonicdns/ValidatorsTest.php
@@ -620,6 +620,42 @@ class ValidatorsTest extends PHPUnit_Framework_TestCase {
 
 		$this->assertTrue($validator->validates());
 		$this->assertEmpty($validator->getErrors());
+
+		// CAA records
+		$data['type'] = "CAA";
+
+		$wrong = array(
+			'only two parts',
+			'a foo "bar"',
+			'0 foo "bar"',
+			'256 issuewild "bar"'
+		);
+
+		$right = array(
+			'0 issue "bar"',
+			'255 issue "comodoca.com"',
+			'7 issue "mailto:foo@bar.com"',
+		);
+
+		foreach($wrong as $w) {
+			printf("Testing /%s/\n", $w);
+			$data['content'] = $w;
+
+			$validator = new RecordValidator($data);
+
+			$this->assertFalse($validator->validates());
+			$this->assertCount(1, $validator->getErrors());
+		}
+
+		foreach($right as $r) {
+			printf("Testing /%s/\n", $r);
+			$data['content'] = $r;
+
+			$validator = new RecordValidator($data);
+
+			$this->assertTrue($validator->validates());
+			$this->assertEmpty($validator->getErrors());
+		}
 	}
 }
 


### PR DESCRIPTION
Add support for the CAA record type.

Requires PowerDNS version >= 4.0.